### PR TITLE
Update/fix Python 3 compatibility

### DIFF
--- a/fn/iters.py
+++ b/fn/iters.py
@@ -1,9 +1,8 @@
-from sys import version
+from sys import version_info
 from collections import deque
 from operator import itemgetter, attrgetter
 from functools import partial
-from itertools import (islice, chain, 
-                       izip, imap, ifilter, 
+from itertools import (islice, chain,                        
                        starmap, repeat, tee, cycle,
                        takewhile, dropwhile,
                        combinations)
@@ -14,22 +13,28 @@ from .func import F
 # Syntax sugar to deal with Python 2/Python 3 
 # differences: this one will return generator
 # even in Python 2.*
-map = imap if version.startswith("2") else map
-filter = ifilter if version.startswith("2") else filter
-zip = izip if version.startswith("2") else zip
+if version_info.major == 2:
+    from itertools import izip, imap, ifilter
+    filter = ifilter
+    map = imap
+    zip = izip    
+else:
+    filter = filter
+    map = map
+    zip = zip
 
-if version.startswith("3"):
+if version_info.major == 3:
     from functools import reduce
 reduce = reduce 
-range = xrange if version.startswith("2") else  range
+range = xrange if version_info.major == 2 else  range
 
-if version.startswith("2"):
+if version_info.major == 2:
     from itertools import ifilterfalse as filterfalse
 else:
     from itertools import filterfalse
 filterfalse = filterfalse
 
-if version.startswith("2"):
+if version_info.major == 2:
     from itertools import izip_longest as zip_longest
 else:
     from itertools import zip_longest
@@ -117,7 +122,7 @@ def roundrobin(*iterables):
     http://docs.python.org/3.4/library/itertools.html#itertools-recipes
     """
     pending = len(iterables)
-    next_attr = "next" if version.startswith("2") else "__next__"
+    next_attr = "next" if version_info.major == 2 else "__next__"
     nexts = cycle(map(attrgetter(next_attr), map(iter, iterables)))
     while pending:
         try:
@@ -165,7 +170,7 @@ def pairwise(iterable):
     """
     a, b = tee(iterable)
     next(b, None)
-    return izip(a, b)
+    return zip(a, b)
 
 def iter_except(func, exception, first=None):
     """ Call a function repeatedly until an exception is raised.

--- a/fn/op.py
+++ b/fn/op.py
@@ -1,10 +1,11 @@
-from sys import version
+from sys import version_info
 
 identity = lambda arg: arg
-apply = apply if version.startswith("2") else _apply
 
-def _apply(f, args, kwargs=None):
-    return f(*args, **(kwargs or {}))
+def _apply(f, args=None, kwargs=None):
+    return f(*(args or []), **(kwargs or {}))
+
+apply = apply if version_info.major == 2 else _apply
 
 def flip(f):
     """Return function that will apply arguments in reverse order"""

--- a/fn/stream.py
+++ b/fn/stream.py
@@ -1,4 +1,10 @@
-from sys import maxint, version
+from sys import version_info
+
+if version_info.major == 2:
+    from sys import maxint
+else:
+    from sys import maxsize as maxint
+
 from itertools import chain
 
 class Stream(object):
@@ -22,7 +28,7 @@ class Stream(object):
 
             raise StopIteration()
 
-        if version.startswith("2"):
+        if version_info.major == 2:
             next = __next__
 
     def __init__(self):
@@ -56,13 +62,13 @@ class Stream(object):
     def __getitem__(self, index):
         if isinstance(index, int):
             # todo: i'm not sure what to do with negative indices
-            if index < 0: raise TypeError, "Invalid argument type"
+            if index < 0: raise TypeError("Invalid argument type")
             self._fill_to(index)
         elif isinstance(index, slice):
             # todo: reimplement to work lazy
             low, high, step = index.indices(maxint)
             self._fill_to(max(low, high))
         else:
-            raise TypeError, "Invalid argument type"
+            raise TypeError("Invalid argument type")
 
         return self._collection.__getitem__(index)

--- a/fn/underscore.py
+++ b/fn/underscore.py
@@ -1,6 +1,7 @@
 import operator
 from .op import identity, curry, apply, flip
 from .func import F
+from sys import version_info
 
 def fmap(f):    
     def applyier(self, other=None):
@@ -51,7 +52,12 @@ class _Callable(object):
     __or__ = fmap(operator.or_)
     __xor__ = fmap(operator.xor)
 
-    __div__ = fmap(operator.div)
+    if version_info.major == 2:
+        div = operator.div
+    else:
+        div = operator.truediv
+
+    __div__ = fmap(div)
     __divmod__ = fmap(divmod)
     __floordiv__ = fmap(operator.floordiv)
     __truediv__ = fmap(operator.truediv)
@@ -75,7 +81,7 @@ class _Callable(object):
     __rsub__ = fmap(flip(operator.sub))
     __rmod__ = fmap(flip(operator.mod))
     __rpow__ = fmap(flip(operator.pow))
-    __rdiv__ = fmap(flip(operator.div))
+    __rdiv__ = fmap(flip(div))
     __rdivmod__ = fmap(flip(divmod))
     __rtruediv__ = fmap(flip(operator.truediv))
     __rfloordiv__ = fmap(flip(operator.floordiv))

--- a/tests.py
+++ b/tests.py
@@ -187,12 +187,12 @@ class UnderscoreTestCase(unittest.TestCase):
         self.assertEqual([0,1,2], list(filter(_ < 5, [0,1,2,10,11,12])))
 
     def test_slicing(self):
-        self.assertEqual(0,       (_[0])(range(10)))
-        self.assertEqual(9,       (_[-1])(range(10)))
-        self.assertEqual([3,4,5], (_[3:])(range(6)))
-        self.assertEqual([0,1,2], (_[:3])(range(10)))
-        self.assertEqual([1,2,3], (_[1:4])(range(10)))
-        self.assertEqual([0,2,4], (_[0:6:2])(range(10)))
+        self.assertEqual(0,       (_[0])(list(range(10))))
+        self.assertEqual(9,       (_[-1])(list(range(10))))
+        self.assertEqual([3,4,5], (_[3:])(list(range(6))))
+        self.assertEqual([0,1,2], (_[:3])(list(range(10))))
+        self.assertEqual([1,2,3], (_[1:4])(list(range(10))))
+        self.assertEqual([0,2,4], (_[0:6:2])(list(range(10))))
 
     def test_slicing_multiple(self):
         self.assertEqual(0, (_[_])(range(10), 0))
@@ -399,4 +399,5 @@ class StreamTestCase(unittest.TestCase):
         self.assertEqual(6765, fib[20])
         self.assertEqual([832040,1346269,2178309,3524578,5702887], fib[30:35])
 
-
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- all: Changed sys.version checks to sys.version_info equivalents
- iters: Made Python 2-specific imports conditional
- op: Fixed _apply to work properly when args=None
- stream: Conditional maxint/maxsize usage in Python 2/3
- underscore: Conditional operator.div/operator.truediv in Python 2/3
- tests: Explicitly convert ranges to lists
- tests: Run tests if tests.py is called directly

All tests pass on Python 3.3 and Python 2.7, should also work on previous versions.
