### PR TITLE
Lazily evaluate Stream slices

### DIFF
--- a/fn/stream.py
+++ b/fn/stream.py
@@ -23,7 +23,7 @@ class Stream(object):
             # check if elements are available for next position
             # return next element or raise StopIteration
             self._position += 1
-            if self._stream._fill_to(self._position):
+            if len(self._stream._collection) > self._position or self._stream._fill_to(self._position):
                 return self._stream._collection[self._position]
 
             raise StopIteration()

--- a/fn/stream.py
+++ b/fn/stream.py
@@ -5,7 +5,7 @@ if version_info.major == 2:
 else:
     from sys import maxsize as maxint
 
-from itertools import chain
+from itertools import chain, imap
 
 class Stream(object):
 
@@ -65,9 +65,11 @@ class Stream(object):
             if index < 0: raise TypeError("Invalid argument type")
             self._fill_to(index)
         elif isinstance(index, slice):
-            # todo: reimplement to work lazy
             low, high, step = index.indices(maxint)
-            self._fill_to(max(low, high))
+            if step == 0: raise ValueError("Step must not be 0")
+            step = step or 1
+            stream_vals = imap(self.__getitem__, xrange(low, high, step))
+            return Stream() << stream_vals
         else:
             raise TypeError("Invalid argument type")
 

--- a/tests.py
+++ b/tests.py
@@ -454,6 +454,12 @@ class StreamTestCase(unittest.TestCase):
         s = Stream() << gen << (4,5)
         assert list(s) == [1,2,3,4,5]
 
+    def test_lazy_slicing(self):
+        s = Stream() << xrange(10)
+        assert len(s._collection) == 0
+        s_slice = s[:5]
+        assert len(s._collection) == 0
+
     def test_fib_infinite_stream(self):
         from operator import add 
 

--- a/tests.py
+++ b/tests.py
@@ -439,7 +439,7 @@ class StreamTestCase(unittest.TestCase):
         s = Stream() << [1,2,3,4,5]
         self.assertEqual([1,2,3,4,5], list(s))
         self.assertEqual(2, s[1])
-        self.assertEqual([1,2], s[0:2])
+        self.assertEqual([1,2], list(s[0:2]))
 
     def test_from_iterator(self):
         s = Stream() << range(6) << [6,7]
@@ -456,9 +456,11 @@ class StreamTestCase(unittest.TestCase):
 
     def test_lazy_slicing(self):
         s = Stream() << xrange(10)
-        assert len(s._collection) == 0
+        self.assertEqual(len(s._collection), 0)
         s_slice = s[:5]
-        assert len(s._collection) == 0
+        self.assertEqual(len(s._collection), 0)
+        self.assertEqual(len(list(s_slice)), 5)
+        # not sure if it's worth testing negative slices, as they cannot be lazy
 
     def test_fib_infinite_stream(self):
         from operator import add 
@@ -468,7 +470,7 @@ class StreamTestCase(unittest.TestCase):
 
         self.assertEqual([0,1,1,2,3,5,8,13,21,34], list(iters.take(10, fib)))
         self.assertEqual(6765, fib[20])
-        self.assertEqual([832040,1346269,2178309,3524578,5702887], fib[30:35])
+        self.assertEqual([832040,1346269,2178309,3524578,5702887], list(fib[30:35]))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This pull request is meant to resolve #6. Right now I've just added a test for the behavior we want to accomplish (which may not even be entirely accurate, but is at least a start).

Right now slicing a Stream seems to return a slice of the underlying collection, which you have implemented as a list. In order to make this lazily evaluated, I was wondering what you thought should be the return type. We could either return a new Stream based off the parameters of the index, or simply a generator. My inclination is to do the former, but I'm open to other suggestions.

Your presentation on Functional Programming totally changed the way I write Python, and I'm a big Scala fan to begin with - I'm very excited to help on this package however I can :)
