### PR TITLE
Made iters.flatten flatten nested iterables of any kind, not just lists

### DIFF
--- a/fn/iters.py
+++ b/fn/iters.py
@@ -33,10 +33,6 @@ else:
     from itertools import filterfalse
     from itertools import zip_longest
 
-# Use str as the base string type for python2/3
-if version_info[0] == 2:
-    str = basestring
-
 def take(limit, base): 
     return islice(base, limit)
 
@@ -195,13 +191,16 @@ def iter_except(func, exception, first=None):
 
 
 def flatten(items):
-    """Flatten any level of nested iterables (not including strings).
+    """Flatten any level of nested iterables (not including strings, bytes or
+    bytearrays).
     Reimplemented to work with all nested levels (not only one).
 
     http://docs.python.org/3.4/library/itertools.html#itertools-recipes
     """
     for item in items:
-        if isinstance(item, Iterable) and not isinstance(item, str):
+        is_iterable = isinstance(item, Iterable)
+        is_string_or_bytes = isinstance(item, (str, bytes, bytearray))
+        if is_iterable and not is_string_or_bytes:
             for i in flatten(item):
                 yield i
         else:

--- a/fn/iters.py
+++ b/fn/iters.py
@@ -1,5 +1,5 @@
 from sys import version_info
-from collections import deque
+from collections import deque, Iterable
 from operator import add, itemgetter, attrgetter
 from functools import partial
 from itertools import (islice, chain,                        
@@ -32,6 +32,10 @@ if version_info[0] == 2:
 else:
     from itertools import filterfalse
     from itertools import zip_longest
+
+# Use str as the base string type for python2/3
+if version_info[0] == 2:
+    str = basestring
 
 def take(limit, base): 
     return islice(base, limit)
@@ -189,18 +193,19 @@ def iter_except(func, exception, first=None):
     except exception:
         pass
 
-def flatten(lists):
-    """Flatten any level of nesting lists.
-    Reimplemented to work not with all nested levels (not only one).
+
+def flatten(items):
+    """Flatten any level of nested iterables (not including strings).
+    Reimplemented to work with all nested levels (not only one).
 
     http://docs.python.org/3.4/library/itertools.html#itertools-recipes
     """
-    for l in lists:
-        if isinstance(l, list):
-            for t in flatten(l):
-                yield t
+    for item in items:
+        if isinstance(item, Iterable) and not isinstance(item, str):
+            for i in flatten(item):
+                yield i
         else:
-            yield l
+            yield item
 
 if version_info[0] == 3 and version_info[1] >= 3:
     from itertools import accumulate

--- a/tests.py
+++ b/tests.py
@@ -465,8 +465,11 @@ class IteratorsTestCase(unittest.TestCase):
         self.assertEqual([0,0,1,0,1,2], list(iters.flatten(generators)))
         # flat list should return itself
         self.assertEqual([1,2,3], list(iters.flatten([1,2,3])))
-        # string is not a list
+        # Don't flatten strings, bytes, or bytearrays
         self.assertEqual([2,"abc",1], list(iters.flatten([2,"abc",1])))
+        self.assertEqual([2, b'abc', 1], list(iters.flatten([2, b'abc', 1])))
+        barray = bytearray(b'abc')
+        self.assertEqual([2, bytearray(b'abc'), 1], list(iters.flatten([2, bytearray(b'abc'), 1])))
 
     def test_accumulate(self):
         self.assertEqual([1,3,6,10,15], list(iters.accumulate([1,2,3,4,5])))

--- a/tests.py
+++ b/tests.py
@@ -453,9 +453,17 @@ class IteratorsTestCase(unittest.TestCase):
         self.assertEqual(["c", "b", "a"], list(it))
 
     def test_flatten(self):
+        # flatten nested lists
         self.assertEqual([1,2,3,4], list(iters.flatten([[1,2], [3,4]])))
         self.assertEqual([1,2,3,4,5,6], list(iters.flatten([[1,2], [3, [4,5,6]]])))
-        # flat list should return themself 
+        # flatten nested tuples, sets, and frozen sets
+        self.assertEqual([1,2,3,4,5,6], list(iters.flatten(((1,2), (3, (4,5,6))))))
+        self.assertEqual([1,2,3], list(iters.flatten(set([1, frozenset([2,3])]))))
+        # flatten nested generators
+        generator_func = lambda n: (num for num in range(0, n))
+        generators = (generator_func(n) for n in range(1, 4))
+        self.assertEqual([0,0,1,0,1,2], list(iters.flatten(generators)))
+        # flat list should return itself
         self.assertEqual([1,2,3], list(iters.flatten([1,2,3])))
         # string is not a list
         self.assertEqual([2,"abc",1], list(iters.flatten([2,"abc",1])))


### PR DESCRIPTION
First off, thank you for fn.py.

I feel like I've implemented flatten() or something like it on several projects. I thought I would  contribute a version that doesn't require the input to be nested lists, but nested iterables of any sort (not including strings).

I kept the original tests and added some for the additional behavior. I also changed the docstring to match the new behavior.

I've tried to match my contribution to the existing style, but just let me know if I've missed anything.
