### PR TITLE
Underscore.call

### DIFF
--- a/fn/underscore.py
+++ b/fn/underscore.py
@@ -49,7 +49,7 @@ class _Callable(object):
 
     def call(self, name, *args):
         """Call method from _ object by given name and arguments"""
-        return self.__class__(F(apply) << operator.attrgetter(name) << F(self))
+        return self.__class__(F(flip(apply), args) << operator.attrgetter(name) << F(self))
 
     def __getattr__(self, name):
         return self.__class__(F(operator.attrgetter(name)) << F(self),

--- a/fn/underscore.py
+++ b/fn/underscore.py
@@ -47,9 +47,9 @@ class _Callable(object):
         self._format_args = format_args
         self._arity = arity
 
-    def call(self, name, *args):
+    def call(self, name, *args, **kwargs):
         """Call method from _ object by given name and arguments"""
-        return self.__class__(F(flip(apply), args) << operator.attrgetter(name) << F(self))
+        return self.__class__(F(lambda f: apply(f, args, kwargs)) << operator.attrgetter(name) << F(self))
 
     def __getattr__(self, name):
         return self.__class__(F(operator.attrgetter(name)) << F(self),

--- a/tests.py
+++ b/tests.py
@@ -186,6 +186,10 @@ class UnderscoreTestCase(unittest.TestCase):
         self.assertEqual(["test", "case"], (_.call("split"))("test case"))
         self.assertEqual("str", _.__name__(str))
 
+    def test_call_method_args(self):
+        self.assertEqual(["test", "case"], (_.call("split", "-"))("test-case"))
+        self.assertEqual(["test-case"], (_.call("split", "-", 0))("test-case"))
+
     def test_comparator(self):
         self.assertTrue((_ < 7)(1))
         self.assertFalse((_ < 7)(10))

--- a/tests.py
+++ b/tests.py
@@ -190,6 +190,11 @@ class UnderscoreTestCase(unittest.TestCase):
         self.assertEqual(["test", "case"], (_.call("split", "-"))("test-case"))
         self.assertEqual(["test-case"], (_.call("split", "-", 0))("test-case"))
 
+    def test_call_method_kwargs(self):
+        test_dict = {'num': 23}
+        _.call("update", num = 42)(test_dict)
+        self.assertEqual({'num': 42}, (test_dict))
+
     def test_comparator(self):
         self.assertTrue((_ < 7)(1))
         self.assertFalse((_ < 7)(10))


### PR DESCRIPTION
Bugfix: the *args in _.call() were completely disregarded in the implementation. be932c3 fixes this, and provides test cases with str.split().

The second commit, 3cf2f30, adds key-word-args to _.call() for the sake of completeness. A test case is added which uses dict.update().

All tests complete without error after both commits, under Python 2.6, 2.7, 3.2 and 3.3.
