### PR TITLE
Additional functions in fn.iters

### DIFF
--- a/fn/iters.py
+++ b/fn/iters.py
@@ -31,6 +31,11 @@ def droplast(n, iterable):
     t1, t2 = tee(iterable)
     return map(itemgetter(0), zip(t1, islice(t2, n, None)))
 
+def compact(iterable):
+    """Return an iterator with all of its falsey items filtered out.
+    """
+    return filter(lambda x: x, iterable)
+
 def consume(iterator, n=None):
     """Advance the iterator n-steps ahead. If n is none, consume entirely.
 

--- a/fn/iters.py
+++ b/fn/iters.py
@@ -1,5 +1,5 @@
 from sys import version_info
-from collections import deque, Iterable
+from collections import deque, Iterable, defaultdict
 from operator import add, itemgetter, attrgetter
 from functools import partial
 from itertools import (islice, 
@@ -10,7 +10,8 @@ from itertools import (islice,
                        cycle,
                        takewhile, 
                        dropwhile,
-                       combinations)
+                       combinations,
+                       groupby as igroupby)
 
 from .op import flip
 from .func import F
@@ -44,6 +45,23 @@ def reject(func, iterable):
           if func is not None else
           (lambda x: not x))
     return filter(fn, iterable)
+
+def groupby(func, iterable):
+    """Return a generator yielding those items of iterable grouped by each
+    value of func(item).
+    """
+    return ((k, si)
+            for k, si in igroupby(sorted(iterable, key=func), func))
+
+def countby(func, iterable):
+    """Return a generator yielding a count for the number of items grouped by
+    each value of func(item).
+    """
+    dd = defaultdict(int)
+    for i in iterable:
+        dd[func(i)] += 1
+    return ((k, v) for k, v in
+            (dd.items() if version_info[0] == 3 else dd.iteritems()))
 
 def consume(iterator, n=None):
     """Advance the iterator n-steps ahead. If n is none, consume entirely.

--- a/fn/iters.py
+++ b/fn/iters.py
@@ -36,6 +36,15 @@ def compact(iterable):
     """
     return filter(lambda x: x, iterable)
 
+def reject(func, iterable):
+    """Return an iterator yielding those items of iterable for which func(item)
+    is false. If func is None, return the items that are false.
+    """
+    fn = ((lambda *args, **kwargs: not func(*args, **kwargs))
+          if func is not None else
+          (lambda x: not x))
+    return filter(fn, iterable)
+
 def consume(iterator, n=None):
     """Advance the iterator n-steps ahead. If n is none, consume entirely.
 

--- a/tests.py
+++ b/tests.py
@@ -410,6 +410,22 @@ class IteratorsTestCase(unittest.TestCase):
                                                 (), ("",), [], [1],
                                                 {}, {"a": 1}])))
 
+    def test_groupby(self):
+        self.assertDictEqual(
+            {"even": [2, 4, 6, 8], "odd": [1, 3, 5, 7, 9]},
+            dict([(k, list(si)) for k, si in
+                  iters.groupby(lambda n: "even" if n % 2 == 0 else "odd",
+                                iters.range(1, 10))])
+        )
+
+    def test_countby(self):
+        self.assertDictEqual(
+            {"even": 5, "odd": 3},
+            dict([(k, v) for k, v in
+                  iters.countby(lambda n: "even" if n % 2 == 0 else "odd",
+                                [1, 2, 3, 4, 5, 6, 8, 10])])
+        )
+
     def test_consume(self):
         # full consuming, without limitation
         r = iters.range(10)

--- a/tests.py
+++ b/tests.py
@@ -388,6 +388,16 @@ class IteratorsTestCase(unittest.TestCase):
         self.assertEqual([0,1], list(iters.droplast(3, range(5))))
         self.assertEqual([], list(iters.droplast(10, range(2))))
 
+    def test_compact(self):
+        self.assertListEqual([], list(iters.compact([None])))
+        self.assertListEqual([True], list(iters.compact([False, True])))
+        self.assertListEqual([1, 0.1], list(iters.compact([0, 1, 0.0, 0.1])))
+        self.assertListEqual([" ", "non-empty"],
+                             list(iters.compact(["", " ", "non-empty"])))
+        self.assertListEqual([("",)], list(iters.compact([(), ("",)])))
+        self.assertListEqual([[0]], list(iters.compact([[], [0]])))
+        self.assertListEqual([{"a": 1}], list(iters.compact([{}, {"a": 1}])))
+
     def test_consume(self):
         # full consuming, without limitation
         r = iters.range(10)

--- a/tests.py
+++ b/tests.py
@@ -399,19 +399,17 @@ class IteratorsTestCase(unittest.TestCase):
         self.assertListEqual([{"a": 1}], list(iters.compact([{}, {"a": 1}])))
 
     def test_reject(self):
-        self.assertListEqual([1, 3, 5],
-                             list(iters.reject(lambda n: n % 2 == 0,
-                                               iters.range(1, 7))))
-        self.assertListEqual([None, False, "", 0, 0.0, (), [], {}],
-                             list(iters.reject(None,
-                                               [None, False, True,
-                                                "", "non-empty",
-                                                0, 1, 0.0, 0.1,
-                                                (), ("",), [], [1],
-                                                {}, {"a": 1}])))
+        self.assertEqual([1, 3, 5],
+                         list(iters.reject(lambda n: n % 2 == 0,
+                                           iters.range(1, 7))))
+        self.assertEqual([None, False, "", 0, 0.0, (), [], {}],
+                         list(iters.reject(None,
+                                           [None, False, True, "", "non-empty",
+                                            0, 1, 0.0, 0.1, (), ("",), [], [1],
+                                            {}, {"a": 1}])))
 
     def test_groupby(self):
-        self.assertDictEqual(
+        self.assertEqual(
             {"even": [2, 4, 6, 8], "odd": [1, 3, 5, 7, 9]},
             dict([(k, list(si)) for k, si in
                   iters.groupby(lambda n: "even" if n % 2 == 0 else "odd",
@@ -419,7 +417,7 @@ class IteratorsTestCase(unittest.TestCase):
         )
 
     def test_countby(self):
-        self.assertDictEqual(
+        self.assertEqual(
             {"even": 5, "odd": 3},
             dict([(k, v) for k, v in
                   iters.countby(lambda n: "even" if n % 2 == 0 else "odd",

--- a/tests.py
+++ b/tests.py
@@ -398,6 +398,18 @@ class IteratorsTestCase(unittest.TestCase):
         self.assertListEqual([[0]], list(iters.compact([[], [0]])))
         self.assertListEqual([{"a": 1}], list(iters.compact([{}, {"a": 1}])))
 
+    def test_reject(self):
+        self.assertListEqual([1, 3, 5],
+                             list(iters.reject(lambda n: n % 2 == 0,
+                                               iters.range(1, 7))))
+        self.assertListEqual([None, False, "", 0, 0.0, (), [], {}],
+                             list(iters.reject(None,
+                                               [None, False, True,
+                                                "", "non-empty",
+                                                0, 1, 0.0, 0.1,
+                                                (), ("",), [], [1],
+                                                {}, {"a": 1}])))
+
     def test_consume(self):
         # full consuming, without limitation
         r = iters.range(10)

--- a/tests.py
+++ b/tests.py
@@ -389,14 +389,14 @@ class IteratorsTestCase(unittest.TestCase):
         self.assertEqual([], list(iters.droplast(10, range(2))))
 
     def test_compact(self):
-        self.assertListEqual([], list(iters.compact([None])))
-        self.assertListEqual([True], list(iters.compact([False, True])))
-        self.assertListEqual([1, 0.1], list(iters.compact([0, 1, 0.0, 0.1])))
-        self.assertListEqual([" ", "non-empty"],
-                             list(iters.compact(["", " ", "non-empty"])))
-        self.assertListEqual([("",)], list(iters.compact([(), ("",)])))
-        self.assertListEqual([[0]], list(iters.compact([[], [0]])))
-        self.assertListEqual([{"a": 1}], list(iters.compact([{}, {"a": 1}])))
+        self.assertEqual([], list(iters.compact([None])))
+        self.assertEqual([True], list(iters.compact([False, True])))
+        self.assertEqual([1, 0.1], list(iters.compact([0, 1, 0.0, 0.1])))
+        self.assertEqual([" ", "non-empty"],
+                         list(iters.compact(["", " ", "non-empty"])))
+        self.assertEqual([("",)], list(iters.compact([(), ("",)])))
+        self.assertEqual([[0]], list(iters.compact([[], [0]])))
+        self.assertEqual([{"a": 1}], list(iters.compact([{}, {"a": 1}])))
 
     def test_reject(self):
         self.assertEqual([1, 3, 5],


### PR DESCRIPTION
Additional functions to be added to `fn.iters` (influenced by Underscore.js):
- `compact`: filter out falsey items from iterable
- `reject`: the opposite of filter
- `groupby`: saner approach to itertools.groupby
- `countby`: similar to groupby, but instead of sub-iterator, it yields a count for the number of items in each group

Unit tests added. Tested with Python 2 (2.7) and Python 3 (3.3).

Thanks for reviewing in advance. Any feedback, positive or negative, would be highly appreciated.

Cheers,
James
