### PR TITLE
Additional functions in fn.iters: compact and reject

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -269,6 +269,7 @@ review status just now.
 -  ``take``, ``drop``
 -  ``takelast``, ``droplast``
 -  ``head``, ``tail``
+-  ``compact``, ``reject``
 -  ``consume``
 -  ``nth``
 -  ``padnone``, ``ncycles``

--- a/fn/iters.py
+++ b/fn/iters.py
@@ -1,6 +1,6 @@
 from sys import version_info
 from collections import deque, Iterable
-from operator import add, itemgetter, attrgetter
+from operator import add, itemgetter, attrgetter, not_
 from functools import partial
 from itertools import (islice, 
                        chain,                        
@@ -14,6 +14,7 @@ from itertools import (islice,
 
 from .op import flip
 from .func import F
+from .underscore import shortcut as _
 from .uniform import *
 
 def take(limit, base): 
@@ -58,6 +59,12 @@ tail = partial(drop, 1)
 
 # shortcut to remove all falsey items from iterable
 compact = partial(filter, None)
+
+def reject(func, iterable):
+    """Return an iterator yielding those items of iterable for which func(item)
+    is false. If func is None, return the items that are false.
+    """
+    return filter(F(not_) << (func or _), iterable)
 
 def padnone(iterable):
     """Returns the sequence elements and then returns None indefinitely.

--- a/fn/iters.py
+++ b/fn/iters.py
@@ -56,6 +56,9 @@ def nth(iterable, n, default=None):
 head = partial(flip(nth), 0)
 tail = partial(drop, 1)
 
+# shortcut to remove all falsey items from iterable
+compact = partial(filter, None)
+
 def padnone(iterable):
     """Returns the sequence elements and then returns None indefinitely.
     Useful for emulating the behavior of the built-in map() function.

--- a/tests.py
+++ b/tests.py
@@ -436,6 +436,15 @@ class IteratorsTestCase(unittest.TestCase):
                                              "", "non-empty", [], [""],
                                              (), (0,), {}, {"a": 1}])))
 
+    def test_reject(self):
+        self.assertEqual([1, 3, 5, 7, 9],
+                         list(iters.reject(_ % 2 == 0, range(1, 11))))
+        self.assertEqual([None, False, 0, 0.0, "", [], (), {}],
+                         list(iters.reject(None, [None, False, True, 0, 1,
+                                                  0.0, 0.1, "", "non-empty",
+                                                  [], [""], (), (0,),
+                                                  {}, {"a": 1}])))
+
     def test_padnone(self):
         it = iters.padnone([10,11])
         self.assertEqual(10, next(it))

--- a/tests.py
+++ b/tests.py
@@ -430,6 +430,12 @@ class IteratorsTestCase(unittest.TestCase):
 
         self.assertEqual([2,3], list(iters.tail(gen())))
 
+    def test_compact(self):
+        self.assertEqual([True, 1, 0.1, "non-empty", [""], (0,), {"a": 1}],
+                         list(iters.compact([None, False, True, 0, 1, 0.0, 0.1,
+                                             "", "non-empty", [], [""],
+                                             (), (0,), {}, {"a": 1}])))
+
     def test_padnone(self):
         it = iters.padnone([10,11])
         self.assertEqual(10, next(it))


### PR DESCRIPTION
Additional functions to be added to `fn.iters`:
- `compact`: shortcut for removing all falsey items from iterable
- `reject`: opposite of `filter`

`tests.py` and `README.rst` updated accordingly.

Thanks a lot.
