### PR TITLE
Implement traditional group-by as found in most other languages like clojure/scala/ruby/etc

### DIFF
--- a/fn/iters.py
+++ b/fn/iters.py
@@ -100,6 +100,17 @@ def grouper(n, iterable, fillvalue=None):
     args = [iter(iterable)] * n
     return zip_longest(*args, fillvalue=fillvalue)
 
+def group_by(keyfunc, iterable):
+    """Returns a dict of the elements from given iterable keyed by result
+    of keyfunc on each element. The value at each key will be a list of
+    the corresponding elements, in the order they appeared in the iterable.
+    """
+    grouped = {}
+    for item in iterable:
+        key = keyfunc(item)
+        grouped.setdefault(key, []).append(item)
+    return grouped
+
 def roundrobin(*iterables):
     """roundrobin('ABC', 'D', 'EF') --> A D E B F C
     Recipe originally credited to George Sakkis.

--- a/fn/iters.py
+++ b/fn/iters.py
@@ -107,8 +107,7 @@ def group_by(keyfunc, iterable):
     """
     grouped = {}
     for item in iterable:
-        key = keyfunc(item)
-        grouped.setdefault(key, []).append(item)
+        grouped.setdefault(keyfunc(item), []).append(item)
     return grouped
 
 def roundrobin(*iterables):

--- a/tests.py
+++ b/tests.py
@@ -490,6 +490,11 @@ class IteratorsTestCase(unittest.TestCase):
         self.assertEqual(["D","E","F"], list(b))
         self.assertEqual(["G","x","x"], list(c))
 
+    def test_group_by(self):
+        iterable = (s for s in ['1', '12', 'a', '123', 'ab'])
+        grouped = iters.group_by(lambda s: len(s), iterable)
+        self.assertEqual({1: ['1', 'a'], 2: ['12', 'ab'], 3: ['123']}, grouped)
+
     def test_roundrobin(self):
         r = iters.roundrobin('ABC', 'D', 'EF')
         self.assertEqual(["A","D","E","B","F","C"], list(r))

--- a/tests.py
+++ b/tests.py
@@ -491,9 +491,17 @@ class IteratorsTestCase(unittest.TestCase):
         self.assertEqual(["G","x","x"], list(c))
 
     def test_group_by(self):
-        iterable = (s for s in ['1', '12', 'a', '123', 'ab'])
-        grouped = iters.group_by(lambda s: len(s), iterable)
+        # verify grouping logic
+        grouped = iters.group_by(len, ['1', '12', 'a', '123', 'ab'])
         self.assertEqual({1: ['1', 'a'], 2: ['12', 'ab'], 3: ['123']}, grouped)
+
+        # verify it works with any iterable - not only lists
+        def gen():
+            yield '1'
+            yield '12'
+
+        grouped = iters.group_by(len, gen())
+        self.assertEqual({1: ['1'], 2: ['12']}, grouped)
 
     def test_roundrobin(self):
         r = iters.roundrobin('ABC', 'D', 'EF')


### PR DESCRIPTION
This default group-by logic is different from what is called groupby within itertools.
