### PR TITLE
Create aliases for iters.head (first) and iters.tail (rest)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -200,7 +200,7 @@ review status just now.
 
 -  ``take``, ``drop``
 -  ``takelast``, ``droplast``
--  ``head``, ``tail``
+-  ``head`` (alias: ``first``), ``tail`` (alias: ``rest``)
 -  ``compact``, ``reject``
 -  ``consume``
 -  ``nth``

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ If you are not sure, what your function is going to do, you can print it:
 Streams and infinite sequences declaration
 ------------------------------------------
 
-Lazy-evaluated scala-style streams. Basic idea: evaluate each new
+Lazy-evaluated Scala-style streams. Basic idea: evaluate each new
 element "on demand" and share calculated elements between all created
 iterators. ``Stream`` object supports ``<<`` operator that means pushing
 new elements when it's necessary.
@@ -240,7 +240,7 @@ Lets take a quick look:
     >>> s3.extract() # <-- s3 isn't changed
     (10, <fn.immutable.heap.SkewHeap object at 0x10b11c052>)
 
-If you think I'm totally crazy and it will work despairingly slow, just give it 5 minutes. Relax, take a deep breathe and read about few techniques that make persistent data structures fast and efficient: `structural sharing <http://en.wikipedia.org/wiki/Persistent_data_structure#Examples_of_persistent_data_structures>`_ and `path copying <http://en.wikipedia.org/wiki/Persistent_data_structure#Path_Copying>`_.
+If you think I'm totally crazy and it will work despairingly slow, just give it 5 minutes. Relax, take a deep breath and read about few techniques that make persistent data structures fast and efficient: `structural sharing <http://en.wikipedia.org/wiki/Persistent_data_structure#Examples_of_persistent_data_structures>`_ and `path copying <http://en.wikipedia.org/wiki/Persistent_data_structure#Path_Copying>`_.
 
 To see how it works in "pictures", you can check great slides from Zach Allaun's talk (StrangeLoop 2013): `"Functional Vectors, Maps And Sets In Julia" <http://goo.gl/Cp1Qsq>`_.
 
@@ -265,7 +265,7 @@ Use appropriate doc strings to get more information about each data structure as
 
 To get more clear vision of how persistent heaps work (``SkewHeap`` and ``PairingHeap``), you can look at slides from my talk `"Union-based heaps" <http://goo.gl/VMgdG2>`_ (with analyzed data structures definitions in Python and Haskell).
 
-**Note.** Most funcitonal languages use persistent data structures as basic building blocks, well-known examples are Clojure, Haskell and Scala. Clojure community puts much effort to popularize programming based on the idea of data immutability. There are few amazing talk given by Rich Hickey (creator of Clojure), you can check them to find answers on both questions "How?" and "Why?":
+**Note.** Most functional languages use persistent data structures as basic building blocks, well-known examples are Clojure, Haskell and Scala. Clojure community puts much effort to popularize programming based on the idea of data immutability. There are few amazing talk given by Rich Hickey (creator of Clojure), you can check them to find answers on both questions "How?" and "Why?":
 
 - `"The Value of Values" <http://goo.gl/137UG5>`_
 - `"Persistent Data Structures and Managed References" <http://goo.gl/M3vZ7E>`_

--- a/fn/iters.py
+++ b/fn/iters.py
@@ -168,7 +168,7 @@ def pairwise(iterable):
     next(b, None)
     return zip(a, b)
 
-def iter_except(func, exception, first=None):
+def iter_except(func, exception, first_=None):
     """ Call a function repeatedly until an exception is raised.
 
     Converts a call-until-exception interface to an iterator interface.
@@ -185,8 +185,8 @@ def iter_except(func, exception, first=None):
     http://docs.python.org/3.4/library/itertools.html#itertools-recipes
     """
     try:
-        if first is not None:
-            yield first()            # For database APIs needing an initial cast to db.first()
+        if first_ is not None:
+            yield first_()            # For database APIs needing an initial cast to db.first()
         while 1:
             yield func()
     except exception:

--- a/fn/iters.py
+++ b/fn/iters.py
@@ -54,8 +54,8 @@ def nth(iterable, n, default=None):
 
 # widely-spreaded shoutcuts to get first item 
 # and all but first item from iterator respectively
-head = partial(flip(nth), 0)
-tail = partial(drop, 1)
+head = first = partial(flip(nth), 0)
+tail = rest = partial(drop, 1)
 
 # shortcut to remove all falsey items from iterable
 compact = partial(filter, None)

--- a/tests.py
+++ b/tests.py
@@ -420,6 +420,9 @@ class IteratorsTestCase(unittest.TestCase):
 
         self.assertEqual(1, iters.head(gen()))
 
+    def test_first(self):
+        self.assertEqual(iters.first, iters.head)  # Check if same object
+
     def test_tail(self):
         self.assertEqual([1,2], list(iters.tail([0,1,2])))
         self.assertEqual([], list(iters.tail([])))
@@ -430,6 +433,9 @@ class IteratorsTestCase(unittest.TestCase):
             yield 3 
 
         self.assertEqual([2,3], list(iters.tail(gen())))
+
+    def test_rest(self):
+        self.assertEqual(iters.rest, iters.tail)  # Check if same object
 
     def test_compact(self):
         self.assertEqual([True, 1, 0.1, "non-empty", [""], (0,), {"a": 1}],


### PR DESCRIPTION
`iters.first` and `iters.rest` as aliases for `iters.head` and `iters.tail` respectively, as used in programming languages like Clojure.

`first` is already in use inside `iters.iter_except`, but the function is already complete and tested, hence such conflict wouldn't cause any harm in my opinion. Optionally, a trailing `_` can be added to make it obvious, provided that it conforms to PEP 8 (http://www.python.org/dev/peps/pep-0008/). For example,

```
if first_ is not None:
    ...
```
