### PR TITLE
Implement iters.iterate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -257,6 +257,7 @@ review status just now.
 -  ``head`` (alias: ``first``), ``tail`` (alias: ``rest``)
 -  ``second``, ``ffirst``
 -  ``compact``, ``reject``
+-  ``iterate``
 -  ``consume``
 -  ``nth``
 -  ``padnone``, ``ncycles``

--- a/fn/iters.py
+++ b/fn/iters.py
@@ -68,6 +68,13 @@ def reject(func, iterable):
     """
     return filter(F(not_) << (func or _), iterable)
 
+def iterate(f, x):
+    """Return an iterator yielding x, f(x), f(f(x)) etc.
+    """
+    while True:
+        yield x
+        x = f(x)
+
 def padnone(iterable):
     """Returns the sequence elements and then returns None indefinitely.
     Useful for emulating the behavior of the built-in map() function.

--- a/tests.py
+++ b/tests.py
@@ -473,6 +473,13 @@ class IteratorsTestCase(unittest.TestCase):
                                                   [], [""], (), (0,),
                                                   {}, {"a": 1}])))
 
+    def test_iterate(self):
+        it = iters.iterate(lambda x: x * x, 2)
+        self.assertEqual(2, next(it))  # 2
+        self.assertEqual(4, next(it))  # 2 * 2
+        self.assertEqual(16, next(it))  # 4 * 4
+        self.assertEqual(256, next(it))  # 16 * 16
+
     def test_padnone(self):
         it = iters.padnone([10,11])
         self.assertEqual(10, next(it))


### PR DESCRIPTION
Influenced by `iterate` in Clojure. I tried to find something similar in Python, but I couldn't. Please let me know if I missed it.

Basically, `iters.iterate(f, x)` returns a lazy sequence of x, f(x), f(f(x)) etc. It's similar to `iters.accumulate` but it takes an initial value, `x`, instead of an iterable.
