### PR TITLE
Add currrying decorator.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -344,6 +344,24 @@ Use case specific for right-side folding is:
     assert 400 == foldr(call, 10)([lambda s: s**2, lambda k: k+10])
 
 
+Function currying
+-----------------
+
+``fn.func.curried`` is a decorator for building curried functions, for example:
+
+.. code-block:: python
+
+    >>> from fn.func import curried
+    >>> @curried
+    ... def sum5(a, b, c, d, e):
+    ...     return a + b + c + d + e
+    ...
+    >>> sum5(1)(2)(3)(4)(5)
+    15
+    >>> sum5(1, 2, 3)(4, 5)
+    15
+
+
 Functional style for error-handling
 -----------------------------------
 
@@ -435,8 +453,6 @@ Work in progress
 
 Ideas to think about:
 
--  Curried function builder to simplify
-   ``lambda arg1: lambda arg2: ...``
 -  Scala-style for-yield loop to simplify long map/filter blocks
 
 Contribute

--- a/fn/func.py
+++ b/fn/func.py
@@ -1,4 +1,5 @@
 from functools import partial
+from inspect import getargspec
 
 from .op import identity, flip
 
@@ -49,3 +50,34 @@ class F(object):
     def  __call__(self, *args, **kwargs):
         """Overload apply operator"""
         return self.f(*args, **kwargs)
+
+
+def curried(func):
+    """A decorator that makes the function curried
+
+    Usage example:
+
+    >>> @curried
+    ... def sum5(a, b, c, d, e):
+    ...     return a + b + c + d + e
+    ...
+    >>> sum5(1)(2)(3)(4)(5)
+    15
+    >>> sum5(1, 2, 3)(4, 5)
+    15
+    """
+    def _curried(*args, **kwargs):
+        f = func
+        count = 0
+        while isinstance(f, partial):
+            if f.args:
+                count += len(f.args)
+            f = f.func
+
+        spec = getargspec(f)
+
+        if count == len(spec.args) - len(args):
+            return func(*args, **kwargs)
+
+        return curried(partial(func, *args, **kwargs))
+    return _curried


### PR DESCRIPTION
Add `curried` decorator, the function is called as soon as the arguments are all given:

``` python
>>> from fn.func import curried
>>> @curried
... def sum5(a, b, c, d, e):
...     return a + b + c + d + e
...
>>> sum5(1)(2)(3)(4)(5)
15
>>> sum5(1, 2, 3)(4, 5)
15
```
