### PR TITLE
Fix #45 and #47

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - 2.7
   - 3.2
   - 3.3
+  - 3.4
   - pypy
 script: 
   - python tests.py

--- a/fn/immutable/__init__.py
+++ b/fn/immutable/__init__.py
@@ -1,5 +1,5 @@
 from .heap import SkewHeap, PairingHeap
-from .list import LinkedList, Stack, Queue, Deque
+from .list import LinkedList, Stack, Queue, Deque as ListDeque
 from .trie import Vector
 from .finger import Deque
 #from .dict import Dict

--- a/fn/immutable/finger.py
+++ b/fn/immutable/finger.py
@@ -41,6 +41,8 @@ class Node3(namedtuple("Node3", "a,b,c")):
 class FingerTree(object):
 
     class Empty(object):
+        __slots__ = ("measure",)
+
         def __init__(self, measure):
             object.__setattr__(self, "measure", measure)
 
@@ -64,6 +66,8 @@ class FingerTree(object):
         def __iter__(self): return iter([])
 
     class Single(object):
+        __slots__ = ("measure", "elem",)
+
         def __init__(self, measure, elem):
             object.__setattr__(self, "measure", measure)
             object.__setattr__(self, "elem", elem)
@@ -88,6 +92,8 @@ class FingerTree(object):
         def __iter__(self): return iter([self.elem])
 
     class Deep(object):
+        __slots__ = ("measure", "left", "middle", "right",)
+
         def __init__(self, measure, left, middle, right):
             object.__setattr__(self, "measure", measure)
             object.__setattr__(self, "left", left)

--- a/fn/immutable/finger.py
+++ b/fn/immutable/finger.py
@@ -38,13 +38,20 @@ class Node3(namedtuple("Node3", "a,b,c")):
         yield self.b
         yield self.c
 
-Empty = namedtuple("Empty", "measure") 
-Single = namedtuple("Single", "measure,elem")
-Deep = namedtuple("Deep", "measure,left,middle,right")
-
 class FingerTree(object):
 
-    class Empty(Empty):
+    class Empty(object):
+        def __init__(self, measure):
+            object.__setattr__(self, "measure", measure)
+
+        def __setattr__(self, *args):
+            raise AttributeError("Attributes of {0} object "
+                                 "cannot be changed".format("Empty"))
+
+        def __delattr__(self, *args):
+            raise AttributeError("Attributes of {0} object "
+                                 "cannot be deleted".format("Empty"))
+
         def is_empty(self): return True
         def head(self): return None
         def last(self): return None
@@ -56,7 +63,19 @@ class FingerTree(object):
             return FingerTree.Single(self.measure, v)
         def __iter__(self): return iter([])
 
-    class Single(Single):
+    class Single(object):
+        def __init__(self, measure, elem):
+            object.__setattr__(self, "measure", measure)
+            object.__setattr__(self, "elem", elem)
+
+        def __setattr__(self, *args):
+            raise AttributeError("Attributes of {0} object "
+                                 "cannot be changed".format("Single"))
+
+        def __delattr__(self, *args):
+            raise AttributeError("Attributes of {0} object "
+                                 "cannot be deleted".format("Single"))
+
         def is_empty(self): return False
         def head(self): return self.elem
         def last(self): return self.elem
@@ -68,7 +87,21 @@ class FingerTree(object):
             return FingerTree.Deep(self.measure, [self.elem], FingerTree.Empty(self.measure), [v])
         def __iter__(self): return iter([self.elem])
 
-    class Deep(Deep):
+    class Deep(object):
+        def __init__(self, measure, left, middle, right):
+            object.__setattr__(self, "measure", measure)
+            object.__setattr__(self, "left", left)
+            object.__setattr__(self, "middle", middle)
+            object.__setattr__(self, "right", right)
+
+        def __setattr__(self, *args):
+            raise AttributeError("Attributes of {0} object "
+                                 "cannot be changed".format("Deep"))
+
+        def __delattr__(self, *args):
+            raise AttributeError("Attributes of {0} object "
+                                 "cannot be deleted".format("Deep"))
+
         def is_empty(self): return False
         def head(self): return self.left[0]
         def last(self): return self.right[-1]

--- a/fn/immutable/finger.py
+++ b/fn/immutable/finger.py
@@ -14,6 +14,8 @@ More information on Wikipedia: http://goo.gl/ppH2nE
 
 from collections import namedtuple
 
+from fn.uniform import reduce
+
 # data Node a = Node2 a a | Node3 a a a
 # data Digit a = One a | Two a a | Three a a a | Four a a a a 
 # data FingerTree a = Empty


### PR DESCRIPTION
This should fix #45 and #47.

The latter appears to be a bug in the PyPy version on Traivs (PyPy 2.2.1 with GCC 4.6.3) which seems to have been addressed in a later version. I could not reproduce the error with PyPy 2.3.0-alpha0 running locally. The alternative solution in the pull request is not as elegant as `collections.namedtuple`, but it would help us move on without having to wait for the next stable release of PyPy.

In addition to the above two, I've
- fixed a naming conflict issue between `immutable.list.Deque` and `immutable.finger.Deque`, and
- added Python 3.4 to the Traivs config
