### PR TITLE
Bugfix underscore format

### DIFF
--- a/fn/underscore.py
+++ b/fn/underscore.py
@@ -21,7 +21,10 @@ def fmap(f, format):
                                   self._arity + other._arity)
         else:
             call = F(flip(f), other) << F(self)
-            return self.__class__(call, fmt.replace("other", "%r"), (other,), self._arity)
+            return self.__class__(call,
+                                  fmt.replace("other", "%r"),
+                                  self._format_args + (other,),
+                                  self._arity)
     return applyier
 
 class ArityError(TypeError):

--- a/tests.py
+++ b/tests.py
@@ -287,6 +287,8 @@ class UnderscoreTestCase(unittest.TestCase):
         self.assertEqual("(x1) => (x1 == 2)", str(_ == 2))
         self.assertEqual("(x1) => (x1 != 2)", str(_ != 2))
 
+        self.assertEqual("(x1) => ((x1 * 2) + 1)", str((_ * 2 + 1)))
+
     def test_rigthside_string_converting(self):
         self.assertEqual("(x1) => (2 + x1)",  str(2 + _))
         self.assertEqual("(x1) => (2 - x1)",  str(2 - _))
@@ -329,9 +331,13 @@ class UnderscoreTestCase(unittest.TestCase):
         self.assertEqual("(x1, x2) => (x1 == x2)", str(_ == _))
         self.assertEqual("(x1, x2) => (x1 != x2)", str(_ != _))
 
+        self.assertEqual("(x1, x2) => (((x1 / x2) - 1) * 100)", str((_ / _ - 1) * 100))
+
     def test_reverse_string_converting(self):
         self.assertEqual("(x1, x2, x3) => ((x1 + x2) + x3)", str(_ + _ + _))
         self.assertEqual("(x1, x2, x3) => (x1 + (x2 * x3))", str(_ + _ * _))
+
+        self.assertEqual("(x1) => (1 + (2 * x1))", str((1 + 2 * _)))
 
     def test_multi_underscore_string_converting(self):
         self.assertEqual("(x1) => (x1 + '_')", str(_ + "_"))


### PR DESCRIPTION
A forgotten tuple addition rendered underscore incapable of formatting
after collecting more than one constant (see tests for more info).

An issue demonstrated in the tests remains open.
underscore formats multiple left side constants with the opposite order.
`str(1 + 2 * _) # (x1) => (2 + (1 * x1))`
I welcome any suggestions on this.

P.S. Regarding the Travis build, it fails because of what the test uncovered.
