### PR TITLE
Bugfix underscore repr

### DIFF
--- a/fn/underscore.py
+++ b/fn/underscore.py
@@ -89,7 +89,7 @@ class _Callable(object):
 
     def __repr__(self):
         """Return original function notation to ensure that eval(repr(f)) == f"""
-        return re.sub(r"x\d", "_", str(self).split("=>", 1)[1].strip())
+        return re.sub(r"x\d+", "_", str(self).split("=>", 1)[1].strip())
 
     def __call__(self, *args):
         if len(args) != self._arity:

--- a/fn/underscore.py
+++ b/fn/underscore.py
@@ -89,7 +89,7 @@ class _Callable(object):
 
     def __repr__(self):
         """Return original function notation to ensure that eval(repr(f)) == f"""
-        return re.sub(r"x\d", "_", str(self).split("=>")[1].strip())
+        return re.sub(r"x\d", "_", str(self).split("=>", 1)[1].strip())
 
     def __call__(self, *args):
         if len(args) != self._arity:

--- a/tests.py
+++ b/tests.py
@@ -345,6 +345,10 @@ class UnderscoreTestCase(unittest.TestCase):
 
     def test_repr_parse_str(self):
         self.assertEqual('=> ' + _, eval(repr('=> ' + _)))
+        self.assertEqual(
+            reduce(lambda f, n: f.format(n), ('({} & _)',) * 11).format('_'),
+            repr(reduce(_ & _, (_,) * 12)),
+        )
 
 class CompositionTestCase(unittest.TestCase):
 

--- a/tests.py
+++ b/tests.py
@@ -346,7 +346,7 @@ class UnderscoreTestCase(unittest.TestCase):
     def test_repr_parse_str(self):
         self.assertEqual('=> ' + _, eval(repr('=> ' + _)))
         self.assertEqual(
-            reduce(lambda f, n: f.format(n), ('({} & _)',) * 11).format('_'),
+            reduce(lambda f, n: f.format(n), ('({0} & _)',) * 11).format('_'),
             repr(reduce(_ & _, (_,) * 12)),
         )
 

--- a/tests.py
+++ b/tests.py
@@ -343,6 +343,9 @@ class UnderscoreTestCase(unittest.TestCase):
         self.assertEqual(_ + _, eval(repr(_ + _)))
         self.assertEqual(_ + _ * _, eval(repr(_ + _ * _)))
 
+    def test_repr_parse_str(self):
+        self.assertEqual('=> ' + _, eval(repr('=> ' + _)))
+
 class CompositionTestCase(unittest.TestCase):
 
     def test_composition(self):


### PR DESCRIPTION
This fixes two bugs in the way `__repr__` parses the returned value of `__str__`.

It splits the result on '=>' but not just on the first valid one. It goes on inside the expression on the right which may contain a literal '=>'.
It also replaces the function arguments with _ but the regex doesn't exhaust the digits of the argument's base. For more than nine arguments, leftover digits from the base remain.

I include test cases for both bugs.

I put them in the same PR branch because they affect the exact same line.
