### PR TITLE
Fix #46 (Implement iters.every and iters.some)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -259,6 +259,7 @@ review status just now.
 -  ``head`` (alias: ``first``), ``tail`` (alias: ``rest``)
 -  ``second``, ``ffirst``
 -  ``compact``, ``reject``
+-  ``every``, ``some``
 -  ``iterate``
 -  ``consume``
 -  ``nth``

--- a/fn/iters.py
+++ b/fn/iters.py
@@ -62,6 +62,12 @@ ffirst = F(first) >> first
 # shortcut to remove all falsey items from iterable
 compact = partial(filter, None)
 
+# shortcuts to 1. return True if f(x) is logical true for every x in
+# iterable (False otherwise), and 2. return the first logical true
+# value of f(x) for any x in iterable (None otherwise) respectively
+every = F(partial(map)) >> all
+some = F(partial(map)) >> compact >> first
+
 def reject(func, iterable):
     """Return an iterator yielding those items of iterable for which func(item)
     is false. If func is None, return the items that are false.

--- a/tests.py
+++ b/tests.py
@@ -477,6 +477,22 @@ class IteratorsTestCase(unittest.TestCase):
                                              "", "non-empty", [], [""],
                                              (), (0,), {}, {"a": 1}])))
 
+    def test_every(self):
+        self.assertEqual(True, iters.every(_ % 2 == 0, [2, 4, 6]))
+        self.assertEqual(False, iters.every(_ % 2 == 0, [1, 3, 5]))
+        self.assertEqual(False, iters.every(_ % 2 == 0, [2, 4, 6, 7]))
+
+    def test_some(self):
+        self.assertEqual("one",
+                         iters.some(lambda k: {1: "one", 2: "two"}.get(k, ""),
+                                    [1, 2]))
+        self.assertEqual(None,
+                         iters.some(lambda k: {1: "one", 2: "two"}.get(k, ""),
+                                    [4, 3]))
+        self.assertEqual("two",
+                         iters.some(lambda k: {1: "one", 2: "two"}.get(k, ""),
+                                    [4, 3, 2]))
+
     def test_reject(self):
         self.assertEqual([1, 3, 5, 7, 9],
                          list(iters.reject(_ % 2 == 0, range(1, 11))))


### PR DESCRIPTION
This pull request implements `iters.every` and `iters.some` as mentioned in #46.

Thanks for reviewing in advance.
