### PR TITLE
Import ABC from collections.abc instead of collections for Python 3.9 compatibility

### DIFF
--- a/fn/iters.py
+++ b/fn/iters.py
@@ -1,5 +1,5 @@
 from sys import version_info
-from collections import deque, Iterable
+from collections import deque
 from operator import add, itemgetter, attrgetter, not_
 from functools import partial
 from itertools import (islice,
@@ -11,6 +11,11 @@ from itertools import (islice,
                        takewhile,
                        dropwhile,
                        combinations)
+
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 from .op import flip
 from .func import F

--- a/fn/monad.py
+++ b/fn/monad.py
@@ -1,4 +1,4 @@
-"""
+r"""
 ``fn.monad.Option`` represents optional values, each instance of 
 ``Option`` can be either instance of ``Full`` or ``Empty``. 
 It provides you with simple way to write long computation sequences 


### PR DESCRIPTION
Fixes #86 