### PR TITLE
Import update to support python 3.10

### DIFF
--- a/fn/iters.py
+++ b/fn/iters.py
@@ -1,5 +1,6 @@
 from sys import version_info
-from collections import deque, Iterable
+from collections import deque
+from collections.abc import Iterable
 from operator import add, itemgetter, attrgetter, not_
 from functools import partial
 from itertools import (islice,


### PR DESCRIPTION
I would like to use cadCAD library with python 3.10. As the library depends on fn.py I prepared an import fix for fn.py to support python 3.10